### PR TITLE
#23 starbucks 예제

### DIFF
--- a/basic_front_end/Starbucks/css/main.css
+++ b/basic_front_end/Starbucks/css/main.css
@@ -18,7 +18,55 @@ a{
   margin: 0 auto;
   position: relative;
 }
-
+.btn{
+  width: 130px;
+  padding: 10px;
+  border: 2px solid #333;
+  border-radius: 4px;
+  color: #333;
+  font-size: 16px;
+  text-align: center;
+  cursor: pointer;
+  box-sizing: border-box;
+  display: block;
+  transition: .4s;
+}
+.btn:hover{
+  background-color: #333;
+  color: #fff;
+}
+.btn.btn--reverse{
+  background-color: #333;
+  color: #fff;
+}
+.btn.btn--reverse:hover{
+  background-color: transparent;
+  color: #333;
+}
+.btn.btn--brown{
+  color: #592b18;
+  border-color: #592b18;
+}
+.btn.btn--brown:hover{
+  color: #FFF;
+  background-color: #592b18;
+}
+.btn.btn--gold{
+  color: #D9AA8A;
+  border-color: #D9AA8A;
+}
+.btn.btn--gold:hover{
+  color: #FFF;
+  background-color: #D9AA8A;
+}
+.btn.btn--white{
+  color: #FFF;
+  border-color: #FFF;
+}
+.btn.btn--white{
+  color: #333;
+  background-color: #FFF;
+}
 
 
 /* Header */
@@ -29,6 +77,7 @@ header {
   border-bottom: 1px solid #c8c8c8;
   position: fixed;
   top: 0;
+  z-index: 9;
 }
 /* 헤더쪽에서 많이 사용 하는 방식 */
 header > .inner{
@@ -191,4 +240,49 @@ header .badges .badge {
   margin-bottom: 12px;
   box-shadow: 4px 4px 10px rgba(0,0,0,.15);
   cursor: pointer;
+}
+
+/* VISUAL */
+.visual {
+  margin-top: 120px;
+  background-image: url("../images/visual_bg.jpg");
+  background-position: center;
+}
+.visual .inner{
+  height: 646px; 
+}
+.visual .title{
+  position: absolute;
+  top: 88px;
+  left: -10px;
+}
+.visual .title .btn{
+  position: absolute;
+  top: 259px;
+  left: 173px;
+}
+.visual .cup1.image{
+  position: absolute;
+  bottom: 0;
+  right: -47px;
+}
+.visual .cup1.text{
+  position: absolute;
+  top: 38px;
+  right: 171px;
+}
+.visual .cup2.image{
+  position: absolute;
+  bottom: 0px;
+  right: 162px;
+}
+.visual .cup2.text{
+  position: absolute;
+  top: 321px;
+  right: 416px;
+}
+.visual .spoon{
+  position: absolute;
+  bottom: 0px;
+  left: 275px;
 }

--- a/basic_front_end/Starbucks/index.html
+++ b/basic_front_end/Starbucks/index.html
@@ -379,6 +379,22 @@
     </div>
   </header>
 
+  <!-- VISUAL -->
+  <section class="visual">
+    <div class="inner">
+
+      <div class="title">
+        <img src="./images/visual_title.png" alt="STARBUCKS DELIGHTFUL START TO THE YEARS" />
+        <a href="javascript:void(0)" class="btn btn--brown">자세히 보기</a>
+      </div>
+      <img src="./images/visual_cup1.png" alt="new OATMEAL LATTE" class="cup1 image" />
+      <img src="./images/visual_cup1_text.png" alt="오트밀 라떼" class="cup1 text" />
+      <img src="./images/visual_cup2.png" alt="new STARBUCKS CARAMEL CRUMBLE MOCHA" class="cup2 image" />
+      <img src="./images/visual_cup2_text.png" alt="스타벅스 카라멜 크럼블 모카" class="cup2 text" />
+      <img src="./images/visual_spoon.png" alt="Spoon" class="spoon" />
+    </div>
+  </section>
+
 </body>
 
 </html>


### PR DESCRIPTION
순차적 애니메이션 - 전역 버튼
사용할 수 있는 버튼 후보 여러개 추가
메인 세션에 들어갈 이미지 삽입
이미지 위치 조정

HTML section 태그는 기능적으로는 의미가 없지만 명시적으로 태그의 영역을 표시해준다.

이미지의 대체 텍스트로 마땅한 것이 없다면, 원래 이미지에 적혀있는 텍스트를 넣는것도 방법이다. 이전에 헤더를 display: fixed를 통해 다른 요소들과 상호작용 하지 않고 뷰포트를 기준으로 배치했기 때문에 section 요소가 헤더에 겹쳐서 나온다. Css 속성으로 수정

.visual .inner은 visual이라는 section 부분을 중앙으로 밀어주는 역할이지 visual과 직접적인 관계는 없다. 그렇기때문에 .visual .inner .title이 아닌 .visual .title로 생략이 가능하다.