### PR TITLE
#25 startbucks 예제 슬라이드 애니메이션 전처리

### DIFF
--- a/basic_front_end/Starbucks/css/main.css
+++ b/basic_front_end/Starbucks/css/main.css
@@ -289,3 +289,86 @@ header .badges .badge {
 .visual .fade-in{
   opacity: 0;
 }
+
+
+/* Notice */
+.notice{
+
+}
+.notice .notice-line{
+  position: relative;
+}
+.notice .notice-line .bg-left{
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  height: 100%;
+  background-color: #333;
+}
+.notice .notice-line .bg-right{
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 50%;
+  height: 100%;
+  background-color: #f6f5ef;
+  
+}
+.notice .notice-line .inner{
+  height: 62px;
+  display: flex;
+}
+.notice .notice-line .inner__left{
+  width: 60%;
+  height: 100%;
+  background-color: #333;
+  display: flex;
+  align-items: center;
+}
+.notice .notice-line .inner__left h2{
+  color:#fff;
+  font-size: 17px;
+  font-weight: 700;
+  margin-right: 20px;
+
+}
+.notice .notice-line .inner__left .swiper-container{
+  height: 62px;
+  background-color: orange;
+  flex-grow: 1;
+}
+.notice .notice-line .inner__left .notice-line__more{
+  width: 62px;
+  height: 62px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.notice .notice-line .inner__left .notice-line__more .material-icons{
+  color:#fff;
+  font-size: 30px;
+
+}
+.notice .notice-line .inner__right{
+  width: 40%;
+  height: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+.notice .notice-line .inner__right h2{
+  font-size: 17px;
+  font-weight: 700;
+}
+.notice .notice-line .inner__right .toggle-promotion{
+  width: 62px;
+  height: 62px;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.notice .notice-line .inner__right .toggle-promotion .material-icons{
+  font-size: 30px;
+}

--- a/basic_front_end/Starbucks/index.html
+++ b/basic_front_end/Starbucks/index.html
@@ -401,6 +401,33 @@
     </div>
   </section>
 
+  <section class="notice">
+
+    <div class="notice-line">
+      <div class="bg-left"></div>
+      <div class="bg-right"></div>
+      <div class="inner">
+
+        <div class="inner__left">
+          <h2>공지사항</h2>
+          <div class="swiper-container"></div>
+          <a href="javascript:void(0)" class="notice-line__more">
+            <div class="material-icons">add_circle</div>
+          </a>
+        </div>
+        <div class="inner__right">
+          <h2>스타벅스 프로모션</h2>
+          <div class="toggle-promotion">
+            <div class="material-icons">upload</div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+  </section>
+
+
 </body>
 
 </html>


### PR DESCRIPTION
슬라이드 애니메이션이 들어갈 요소 작성

.notice .notice-line .inner에 높이를 200px로 설정 하고 부모 요소인 .notice .notice-line에 높이값이 없으니 height 기본값이 auto이다. 세로 넓이가 최대한 줄어들다가, inner 부분에 걸려서 높이가 200px이 되는 것이다. .notice-line 배경들이 height: 100%로 높이를 채우려고 해서 알아서 늘어난다. 결국 notice-line .inner 부분만 높이를 제어하면 알아서 정리가 된다.
그렇지 않으면 각각의 높이를 정의하고 수정할 시 전체를 다 바꿔줘야 하기에 작업이 번거로워 진다. Inner__left 영역은
공지사항이라는 제목(h2), 공지사항이 보일 영역(div class=”swiper-container”), 더보기 버튼으로 구성 및 디자인