### PR TITLE
#31 아이패드 반응형 웹사이트

### DIFF
--- a/basic_front_end/Ipad-Responsive/css/main.css
+++ b/basic_front_end/Ipad-Responsive/css/main.css
@@ -2,7 +2,7 @@ body{
   font-size: 16px;
   line-height: 1;
   font-family: "Roboto", "Noto Sans KR", sans-serif;
-  word-break: keep-all; /* 영어눈 택스트를 단어 단위로 줄바꿈을 해주지만 한글은 안해준다 word-break: keep-all은 한글도 단어 단위로 줄바꾸 하게 해준다' */
+  word-break: keep-all; /* 영어는는 텍스트를 단어 단위로 줄바꿈을 해주지만 한글은 안해준다 word-break: keep-all은 한글도 단어 단위로 줄바꿈꿈 하게 해준다' */
 }
 
 /* HEADER */
@@ -29,6 +29,23 @@ header ul.menu li a{
   color: #f5f5f5;
   opacity: .8;
   text-decoration: none;
+}
+header ul.menu li.apple-logo a,
+header ul.menu li.search-starter a,
+header ul.menu li.basket-starter a{
+  width: 14px;
+  text-indent: -9999px;
+  background-repeat: no-repeat;
+  background-position: center 13px;
+}
+header ul.menu li.apple-logo a{
+  background-image: url("../images/header_apple.svg");
+}
+header ul.menu li.search-starter a{
+  background-image: url("../images/header_search.svg");
+}
+header ul.menu li.basket-starter a{
+  background-image: url("../images/header_bag.svg");
 }
 header ul.menu li a:hover{
   opacity: 1;


### PR DESCRIPTION
icon이 아닌 background-image로 헤더 부분의 애플로고, 검색, 장바구니 대체

text-indent: -9999px은
background-image를 넣었을때 대체 텍스트로 사용된다는 개발자 암묵적인 약속